### PR TITLE
Fix conflict of names of permissions and limits

### DIFF
--- a/plib/controllers/IndexController.php
+++ b/plib/controllers/IndexController.php
@@ -17,12 +17,12 @@ class IndexController extends pm_Controller_Action
 
     public function fakeusersAction()
     {
-        $this->view->fakeUsersLimit = $this->_domain->getLimit('fake_users');
+        $this->view->fakeUsersLimit = $this->_domain->getLimit('max_fake_users');
     }
 
     public function fakesitesAction()
     {
-        $this->view->fakeSitesLimit = $this->_domain->getLimit('fake_sites');
+        $this->view->fakeSitesLimit = $this->_domain->getLimit('max_fake_sites');
     }
 
     public function indexAction()

--- a/plib/hooks/Limits.php
+++ b/plib/hooks/Limits.php
@@ -5,13 +5,13 @@ class Modules_ServiceplanManagement_Limits extends pm_Hook_Limits
     public function getLimits()
     {
         return [
-            'fake_users' => [
+            'max_fake_users' => [
                 'default' => 2,
                 'place' => self::PLACE_MAIN,
                 'name' => 'Fake users',
                 'description' => 'Fake users limit, exposed by service plan management sdk.',
             ],
-            'fake_sites' => [
+            'max_fake_sites' => [
                 'default' => 10,
                 'place' => self::PLACE_ADDITIONAL,
                 'name' => 'Fake sites',


### PR DESCRIPTION
Add prefix 'max_' to the names of limits
